### PR TITLE
Marker InfoDialog

### DIFF
--- a/src/components/css/marker.css
+++ b/src/components/css/marker.css
@@ -13,9 +13,9 @@
 }
 
 .marker-info img {
-  height: auto;
+  height: 10%;
   margin-top: 7px;
-  width: 75px;
+  width: 10%;
 }
 
 .marker-header {

--- a/src/components/css/marker.css
+++ b/src/components/css/marker.css
@@ -4,6 +4,8 @@
 }
 
 .marker-info {
+  width: 150px;
+  height: 150px;
   color:  #3b4141;
   margin: 10px;
 }
@@ -13,15 +15,15 @@
 }
 
 .marker-info img {
-  height: 10%;
+  height: 25%;
   margin-top: 7px;
-  width: 10%;
+  width: 25%;
 }
 
 .marker-header {
   font-weight: bold;
   font-size: 22px;
-  margin: 5px 0px 15px 0px;
+  padding-bottom: 5px;
 }
 
 .marker-desc {


### PR DESCRIPTION
Constrain marker info so it doesn't stretch info dialog. Remove height: auto.